### PR TITLE
Binary strings

### DIFF
--- a/python/matasano/set1/c1.py
+++ b/python/matasano/set1/c1.py
@@ -1,12 +1,12 @@
 from matasano.util.converters import *
 
 hex_input = "49276d206b696c6c696e6720796f757220627261696e206c696b65206120706f69736f6e6f7573206d757368726f6f6d"
-#print hex_input
 
-def hex_to_base64(hex):
-	base64= read_hex(hex)
-	base64= bytes_to_base64(base64)
+def hex_to_base64(hexstr):
+	bstr = hex_to_bytestr(hexstr)
+	base64 = bytes_to_base64(bstr)
+
 	return base64
 
-base64=hex_to_base64(hex_input)
+base64 = hex_to_base64(hex_input)
 print(base64)

--- a/python/matasano/set1/c2.py
+++ b/python/matasano/set1/c2.py
@@ -1,5 +1,5 @@
 from matasano.util.converters import *
-from matasano.util.byte_xor import *
+from matasano.util.byte_xor import xor
 
 hexinput1 = "1c0111001f010100061a024b53535009181c"
 hexinput2 = "686974207468652062756c6c277320657965"
@@ -15,11 +15,12 @@ def hex_string_xor(hex1string, hex2string):
     assert type(hex1string) == str
     assert type(hex2string) == str
     
-    hex1bytes = read_hex(hex1string)
-    hex2bytes = read_hex(hex2string)
+    hex1bytes = hex_to_bytestr(hex1string)
+    hex2bytes = hex_to_bytestr(hex2string)
     
-    outputbytes = byte_list_xor(hex1bytes, hex2bytes)
-    outputstring = bytes_to_hex_string(outputbytes)
+    outputbytes = xor(hex1bytes, hex2bytes)
+    print outputbytes
+    outputstring = bytestr_to_hex(outputbytes)
     
     return outputstring
     

--- a/python/matasano/set1/challenge-3.py
+++ b/python/matasano/set1/challenge-3.py
@@ -1,8 +1,10 @@
 import matasano.util.converters as converters
+from matasano.util.byte_xor import xor
+
 input1='1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736'
 
-Bytes=converters.read_hex(input1)
-print ('Bytes:',Bytes)
+Bytes = converters.hex_to_bytestr(input1)
+print 'Bytes:', `Bytes`
 
 potential_keys=[]
 
@@ -13,25 +15,30 @@ def repeated(bytestring):
         if bytestring[i]==bytestring[i+1]:
             repeated.append(bytestring[i])
     return repeated
+
 # if a repeated character exists, the potential keys are reduced to keys which
 # will decrypt to a repeated character found in the English language, namely s,e,t,m,o
 if len(repeated(Bytes))>0:
     for item in repeated(Bytes):
-        potential_keys.extend((item^ord('s'),item^ord('e'),item^ord('t'),item^ord('l'),item^ord('m'),item^ord('o')))
-    print('Repeated letters found.  Only relevant keys added.')
-    print ('Current potential keys:', potential_keys)
-    print ('Current number of potential keys:', len(potential_keys))
+        for k in ['s', 'e', 't', 'l', 'm', 'o']:
+            potential_keys.append(xor(item, k))
+    # Unique potential keys.
+    potential_keys = list(set(potential_keys))
+
+    print 'Repeated letters found.  Only relevant keys added.'
+    print 'Current potential keys:', potential_keys
+    print 'Current number of potential keys:', len(potential_keys)
     # removes potential keys which are not printable characters
     for k in potential_keys:
-        if k not in range(32,127):
+        if not converters.valid_characters(k):
             potential_keys.remove(k)
-    print ('Current number of potential keys:', len(potential_keys))
+    print 'Current number of potential keys:', len(potential_keys)
 else:
     for k in range (32,127):
-        potential_keys.append(k)
-    print('No repeated letters found.  All relevant keys added.')
-    print ('Current potential keys:', potential_keys)
-    print ('Current number of potential keys:', len(potential_keys))
+        potential_keys.append(chr(k))
+    print 'No repeated letters found.  All relevant keys added.'
+    print 'Current potential keys:', potential_keys
+    print 'Current number of potential keys:', len(potential_keys)
 
 def decrypt(k,c):
     """
@@ -41,34 +48,25 @@ def decrypt(k,c):
     param c: ciphertext bytes
     return a string of bytes
     """
-    decrypted_bytes=[]
+    decrypted = ''
     for byte in c:
-        decrypted_bytes.append(byte^k)
-    return decrypted_bytes
+        decrypted += xor(byte, k)
+
+    return decrypted
+
 # this checks the potential keys and removes any which result in invalid decryptions
 for k in potential_keys:
-    decrypted=decrypt(k,Bytes)
-    if not converters.valid_character(decrypted):
+    decrypted = decrypt(k, Bytes)
+    print decrypted
+    if not converters.valid_characters(decrypted):
         potential_keys.remove(k)
-print('\n Keys which return invalid decryptions filtered out.')
-print ('Current potential keys:', potential_keys)
-print ('Current number of potential keys:', len(potential_keys))
-
-def plaintext(k,bytes):
-    """
-    xors the ciphertext bytestring with key k and returns as ascii
-
-    param k: key
-    param c: ciphertext bytes
-    return a string of ascii characters
-    """
-    decrypted=decrypt(k,bytes)
-    plaintext=converters.bytes_to_char(decrypted)
-    return plaintext
+print '\n Keys which return invalid decryptions filtered out.'
+print 'Current potential keys:', potential_keys
+print 'Current number of potential keys:', len(potential_keys)
 
 candidate_plaintext={}
 for k in potential_keys:
-    candidate_plaintext[k]=plaintext(k,Bytes)
+    candidate_plaintext[k] = decrypt(k,Bytes)
 
 def most(charstring): # returns an ordered array of the most common bytes
     occurrences={} # creates a lookup so that occourances[byte] will return the number of
@@ -85,7 +83,7 @@ def most(charstring): # returns an ordered array of the most common bytes
         del occurrences[max(occurrences, key=occurrences.get)]
     return most
 
-def score(charstring):
+def score_string(charstring):
     score=0
     scoring={' ':13, 'e':12, 't':11, 'a':10, 'o':9, 'i':8, 'n':7, 's':6, 'h':5, 'r':4, 'd':3, 'l':2, 'u':1}
     Most=most(charstring)
@@ -96,8 +94,8 @@ def score(charstring):
 
 Score={}
 for k in potential_keys:
-    Score[k]=score(candidate_plaintext[k])
+    Score[k]=score_string(candidate_plaintext[k])
 
 key=max(Score, key=Score.get)
-print(candidate_plaintext[key])
-print('key: ', chr(key))
+print candidate_plaintext[key]
+print 'key: ', key

--- a/python/matasano/util/byte_xor.py
+++ b/python/matasano/util/byte_xor.py
@@ -1,7 +1,7 @@
-def byte_list_xor(input1, input2):
+def xor(input1, input2):
     """
-    A function that takes two input byte lists and returns the bitwise xor
-    of the two lists
+    Takes two byte strings and returns the bitwise xor
+    of them.
     
     :param input1: a list of 8 bit integers
     :param input2: a list of 8 bit integers

--- a/python/matasano/util/byte_xor.py
+++ b/python/matasano/util/byte_xor.py
@@ -1,22 +1,21 @@
 def byte_list_xor(input1, input2):
     """
-    A function that takes two input byte lists and returns the bitwise xor of the two lists
+    A function that takes two input byte lists and returns the bitwise xor
+    of the two lists
     
     :param input1: a list of 8 bit integers
     :param input2: a list of 8 bit integers
     :return: a list of 8 bit integers
     """
-    outputlist = []
-    assert type(input1) == list
-    assert type(input2) == list
-    for x in input1:
-        assert type(x) == int
+    out = ''
+    assert type(input1) == str
+    assert type(input2) == str
     
     if (len(input1) != len(input2)):
-        raise ValueError('byte_list_xor: input lists of unequal length')
+        raise ValueError('byte_list_xor: input strings of unequal length')
     
-    for x in range(len(input1)):
-        outputlist.append(input1[x] ^ input2[x])
+    for c1, c2 in zip(input1, input2):
+        xor = ord(c1) ^ ord(c2)
+        out += chr(xor)
     
-    return outputlist
-
+    return out

--- a/python/matasano/util/converters.py
+++ b/python/matasano/util/converters.py
@@ -1,52 +1,17 @@
-def hex_to_byte(charin):
-    """
-    Convert an ASCII encoded hex character into it's corresponding 4 bit hex number.
-    
-    :param charIn: a string containing one character
-    :return: a 4 bit integer
-    """
-    assert type(charin) == str
-    assert len(charin) == 1
-    charin=ord(charin) # converts charIn to its `integer' value (the ascii encoding value)
-    if 48<= charin and charin <=57: # converts 0-9 characters to integers
-        charin=charin-48
-    elif 65<= charin and charin <=70: # converts uppercase to integers
-        charin=charin-55
-    elif 97<= charin and charin<=102: # converts lowercase to integers
-        charin=charin-87
-    else:
-        raise ValueError('Invalid hex character')
-    return charin
+import binascii
 
-def combine_hex(msb, lsb):
+def hex_to_bytestr(hex_string):
     """
-    Combines two 4 bit numbers into one 8 bit number
-    e.g. combine_hex(4,8) would return 0x48
-    
-    :param msb: a 4 bit integer
-    :param lsb: a 4 bit integer
-    :return: an 8 bit integer
+    Returns a byte string from its hexadecimal expression.
     """
-    assert type(msb) == int
-    assert type(lsb) == int
-    msb=msb<<4 # puts the significant bits on the left
-    output=msb | lsb # or of first and second
-    return output
+    return binascii.unhexlify(hex_string)
 
-def read_hex(hexstring):
+def bytestr_to_hex(byte_string):
     """
-    Creates a list of 8 bit numbers from a hex string
-    
-    :param hexstring: a string of ASCII encoded characters
-    :return: a list of 8 bit numbers
+    Returns the hexadecimal representation (string)
+    of a binary string.
     """
-    assert type(hexstring) == str
-    byteVals=[]
-    if len(hexstring)%2!=0:
-        raise ValueError('read_hex: Odd number of hex characters input.')
-    for i in range(0,len(hexstring)-1,2):
-        byteVals.append(combine_hex(hex_to_byte(hexstring[i]),hex_to_byte(hexstring[i+1])))
-    return byteVals
+    return binascii.unhexlify(byte_string)
 
 def base64_splitter(eightbitnumbers): 
     """
@@ -115,53 +80,6 @@ def bytes_to_base64(eightbitnumbers):
     elif length%3==2:
         outputstring = outputstring[:len(outputstring) - 1] + '='
     return outputstring
-
-def to_hex(inputnum):
-    """
-    A function that takes a 4 bit number as input and returns a one character string of the hex character representing that number
-    
-    :param inputnum: an 8 bit integer
-    :return: a string of length 1
-    """
-    assert type(inputnum) == int
-    
-    if 0 <= inputnum and inputnum <= 9:
-        return chr(inputnum + 48)
-    elif 10 <= inputnum and inputnum <= 15:
-        return chr(inputnum + 87)
-    else:
-        raise ValueError('to_hex: Invalid hex character')
-
-def bytes_to_hex_string(eightbitnumbers):
-    """
-    Converts a list of 8 bit numbers into an ASCII encoded hex string
-    
-    :param eightbitnumbers: a list of integers
-    :return: a string of ASCII characters
-    """
-    assert type(eightbitnumbers) == list
-    for x in eightbitnumbers:
-        assert type(x) == int
-    
-    outputstring = ""
-    
-    for x in range(len(eightbitnumbers)):
-        outputstring += to_hex(eightbitnumbers[x] >> 4) #select 4 msb from eightbitnumbers[x]
-        outputstring += to_hex(eightbitnumbers[x] & 0xF) #select 4 lsb from eightbitnumbers[x]
-    
-    return outputstring
-
-def bytes_to_char(byteinput):
-    """
-    Converts a list of bytes into a list of ASCII characters
-
-    param byteinput: a list of bytes
-    return a string of ASCII characters
-    """
-    chars=''
-    for x in byteinput:
-        chars+=chr(x)
-    return chars
 
 def valid_character(byteinput):
     """

--- a/python/matasano/util/converters.py
+++ b/python/matasano/util/converters.py
@@ -58,27 +58,33 @@ def to_base64(inputnum): # returns the base64 byte characters
     else:
         raise ValueError('Invalid base64 input')
 
-def bytes_to_base64(eightbitnumbers):
+def bytes_to_base64(bytestr):
     """
-    Convert a list of eight bit numbers into the corresponding base64 encoded string
+    Convert a string of bytes into the corresponding base64 encoded string
     
     :param eight_bit_numbers: a list of 8 bit integer values
     :return: a string of ASCII characters
     """
-    assert type(eightbitnumbers) == list
-    for x in eightbitnumbers:
-        assert type(x) == int
-    length=len(eightbitnumbers)
-    while len(eightbitnumbers)%3!=0: # pads input to multiple of 3
-        eightbitnumbers.append(0)
-    temp=base64_splitter(eightbitnumbers)
+    assert type(bytestr) == str
+
+    length = len(bytestr)
+    # Pad the length to the next multiple of 3.
+    while len(bytestr) % 3 != 0:
+        bytestr += '\x00'
+
+    # Convert byte string to string of 8-bit integers.
+    intstr = [ord(b) for b in bytestr]
+
+    tmp = base64_splitter(intstr)
+
     outputstring = ""
-    for i in range(0,len(temp)):
-        outputstring+=to_base64(temp[i])
-    if length%3==1:
+    for i in range(0,len(tmp)):
+        outputstring += to_base64(tmp[i])
+    if length % 3 == 1:
         outputstring = outputstring[:len(outputstring) - 2] + '=='
-    elif length%3==2:
+    elif length % 3 == 2:
         outputstring = outputstring[:len(outputstring) - 1] + '='
+
     return outputstring
 
 def valid_character(byteinput):
@@ -89,8 +95,9 @@ def valid_character(byteinput):
     return: false if the bytes contain an invalid ASCII character, true otherwise
     """
     for x in byteinput:
-        if x<=31 or x>=127:
-            if x!=9 and x!=10 and x!=11: # 9 is hotizontal tab, 10 is newline, 11 is vertical tab
+        c = ord(x)
+        if c<=31 or c>=127:
+            if c!=9 and c!=10 and c!=11: # 9 is hotizontal tab, 10 is newline, 11 is vertical tab
                 return False
     else:
         return True

--- a/python/matasano/util/converters.py
+++ b/python/matasano/util/converters.py
@@ -87,18 +87,20 @@ def bytes_to_base64(bytestr):
 
     return outputstring
 
-def valid_character(byteinput):
+def valid_characters(bytestr):
     """
-    Checks an list of bytes for valid English characters
+    Returns True if the byte string provided contains only
+    characters of the alphabet or newline, tab, vertical
+    bar.
+    Returns False otherwise.
 
     param byteinput: a list of bytes
     return: false if the bytes contain an invalid ASCII character, true otherwise
     """
-    for x in byteinput:
-        c = ord(x)
-        if c<=31 or c>=127:
-            if c!=9 and c!=10 and c!=11: # 9 is hotizontal tab, 10 is newline, 11 is vertical tab
-                return False
-    else:
+    for b in bytestr.upper():
+        if not b in range(ord('A'), ord('Z')):
+            return False
+        if not b in [ord('\t'), ord('\n'), ord('|')]:
+            return False
+    else: 
         return True
-

--- a/python/matasano/util/converters.py
+++ b/python/matasano/util/converters.py
@@ -11,7 +11,7 @@ def bytestr_to_hex(byte_string):
     Returns the hexadecimal representation (string)
     of a binary string.
     """
-    return binascii.unhexlify(byte_string)
+    return binascii.hexlify(byte_string)
 
 def base64_splitter(eightbitnumbers): 
     """


### PR DESCRIPTION
This solves #37.

To represent a string of bytes we simply create a string of ASCII characters.
For example, the string:
```
bytestr = '\xcc\x0b\xfaA'
```
represents the hexadecimal value 0xcc0bfa41.
Note that we use the form '\xcc' to indicate the hexadecimal 0xcc.

In our code you can convert from a string of hexadecimal values (e.g.: 'cc0bfa41') to a byte
string by using the function hex_to_bytestr().
You can convert from a byte string to a string of hexadecimal values using bytestr_to_hex().

Note that a byte string is already a string of ASCII characters, so we do not need
to create functions that convert from a byte string to a string of characters.
You can use valid_characters() to see if a byte string contains any non-printable character.
NOTE: IMHO this function should be amended to check for ANY non-printable character.

If you need to work on a single byte you can use the standard functions ord() to convert a character (byte) to its integer value, chr() to move from an integer in [0,255] to its ASCII value.

This PR also includes changes to adapt the code of previous challenges to the new convention.

A remark: commit 41f300a quickly adapts the base64 code to the new convention, by converting a string to the old convention. It would be nice to make its code purely with the new convention.
Also: why don't we put the base64 code in a separate file?